### PR TITLE
Use path option instead of wiki-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
         with:
           # Whatever directory you choose will be mirrored to the GitHub
           # .wiki.git. The default is .github/wiki.
-          wiki-directory: wiki
+          path: wiki
           # For now, you'll need to manually specify a GitHub token until we
           # solve #2. The x: prefix is a dummy username.
           token: x:${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ one of your GitHub Actions workflows.
 ```yml
 - uses: spenserblack/actions-wiki@v0.1.1
   with:
-    wiki-directory: .
+    path: .
     # Notice that we use a github.com/ prefix here to support enterprise GitHub
     # deployments on other domains.
     repository: github.com/octocat/gigantic-mega-project
@@ -88,7 +88,7 @@ one of your GitHub Actions workflows.
 - **`token`:** `${{ github.token }}` is the default. This token is used when
   cloning and pushing wiki changes.
 
-- **`wiki-directory`:** The directory to use for your wiki contents. Default:
+- **`path`:** The directory to use for your wiki contents. Default:
   `.github/wiki`.
 
 - **`commit-message`:** The message to use when committing new content. Default

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
       wiki changes.
     required: true
     default: ${{ github.token }}
-  wiki-directory:
+  path:
     description: >-
       The directory to use for your wiki contents. Default .github/wiki.
     required: true
@@ -39,5 +39,5 @@ runs:
       env:
         INPUT_REPOSITORY: ${{ inputs.repository }}
         INPUT_TOKEN: ${{ inputs.token }}
-        INPUT_WIKI_DIRECTORY: ${{ inputs.wiki-directory }}
+        INPUT_PATH: ${{ inputs.path }}
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}

--- a/src/index.sh
+++ b/src/index.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd "$INPUT_WIKI_DIRECTORY"
+cd "$INPUT_PATH"
 
 git init
 git config --local user.name github-actions


### PR DESCRIPTION
This is more conventional across most other GitHub Actions. Specifically drawing inspiration from the GitHub Pages deployment workflow.

This PR would...
- [x] Change the wiki-directory to path in action.yml
- [x] Change the INPUT_WIKI_DIRECTORY var to INPUT_PATH in index.sh
- [x] Change the text in readme.md to match