### PR TITLE
Write rev before deploying wiki

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Write Rev
+        run: 'git log -1 --format="%H" > .github/wiki/Rev.md'
       - uses: ./
         with:
           # For now, you'll need to manually specify a GitHub token until we


### PR DESCRIPTION
This writes the last commit SHA of the main repository before committing
and deploying the changes to the wiki.
