### PR TITLE
Make token semantics match actions/checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ jobs:
           # Whatever directory you choose will be mirrored to the GitHub
           # .wiki.git. The default is .github/wiki.
           path: wiki
-          # For now, you'll need to manually specify a GitHub token until we
-          # solve #2. The x: prefix is a dummy username.
-          token: x:${{ secrets.GITHUB_TOKEN }}
 ```
 
 <img align="right" alt="Screenshot of 'Create the first page' button" src="https://i.imgur.com/ABKIS4h.png" />
@@ -75,7 +72,7 @@ one of your GitHub Actions workflows.
     # deployments on other domains.
     repository: github.com/octocat/gigantic-mega-project
     # Make sure this token has the appropriate push permissions!
-    token: x:${{ secrets.GIGANTIC_MEGA_PROJECT_GITHUB_TOKEN }}
+    token: ${{ secrets.GIGANTIC_MEGA_PROJECT_GITHUB_TOKEN }}
 ```
 
 ### Options

--- a/src/index.sh
+++ b/src/index.sh
@@ -4,7 +4,7 @@ set -e
 # shellcheck source=src/git_exists.sh
 source "$(dirname "${BASH_SOURCE[0]}")/git_exists.sh"
 
-if ! git_exists "https://x:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git" &>/dev/null; then
+if ! git_exists "https://$GITHUB_ACTOR:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git" &>/dev/null; then
   echo "$(basename "$0"): https://$INPUT_REPOSITORY.wiki.git doesn't exist." >&2
   echo 'Did you remember to create the first wiki page manually?' >&2
   echo 'You can find more information on the readme. [1]' >&2
@@ -18,7 +18,7 @@ cd "$INPUT_PATH"
 git init
 git config --local user.name github-actions
 git config --local user.email github-actions@github.com
-git remote add origin "https://x:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git"
+git remote add origin "https://$GITHUB_ACTOR:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git"
 git fetch origin
 git reset origin/master
 

--- a/src/index.sh
+++ b/src/index.sh
@@ -4,7 +4,7 @@ set -e
 # shellcheck source=src/git_exists.sh
 source "$(dirname "${BASH_SOURCE[0]}")/git_exists.sh"
 
-if ! git_exists "https://$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git" &>/dev/null; then
+if ! git_exists "https://x:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git" &>/dev/null; then
   echo "$(basename "$0"): https://$INPUT_REPOSITORY.wiki.git doesn't exist." >&2
   echo 'Did you remember to create the first wiki page manually?' >&2
   echo 'You can find more information on the readme. [1]' >&2
@@ -18,7 +18,7 @@ cd "$INPUT_PATH"
 git init
 git config --local user.name github-actions
 git config --local user.email github-actions@github.com
-git remote add origin "https://$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git"
+git remote add origin "https://x:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git"
 git fetch origin
 git reset origin/master
 


### PR DESCRIPTION
this pr would...
- [x] make it say `token: ${{ secrets.TOKENHERE }}` in readme
- [x] use `https://x:$TOKEN@github.com/user/repo.wiki.git` in git ops
- [x] set default to `token: ${{ github.token }}` in action.yml
- [x] not change anything else