### PR TITLE
Support non-master default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ one of your GitHub Actions workflows.
   is `Update wiki ${{ github.sha }}`. You probably don't need to change this,
   since this only applies if you look _really closely_ in your wiki.
 
+- **`branch` :** The branch which the wiki tacks on. Default `master`.
+
 - **`dry-run`:** Whether or not to actually attempt to push changes back to the
   wiki itself. If this is set to `true`, we instead print the remote URL and do
   not push to the remote wiki. The default is `false`. This is useful for

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ inputs:
       applies if you look really closely in your wiki.
     required: true
     default: Update wiki ${{ github.sha }}
+  branch:
+    descripton: >-
+      The branch which the wiki tacks on. Default master.
+    required: false
+    default: master
   dry-run:
     description: >-
       Whether or not to actually attempt to push changes back to the wiki
@@ -48,4 +53,5 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}

--- a/src/index.sh
+++ b/src/index.sh
@@ -20,7 +20,7 @@ git config --local user.name github-actions
 git config --local user.email github-actions@github.com
 git remote add origin "https://$GITHUB_ACTOR:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki.git"
 git fetch origin
-git reset origin/master
+git reset origin/$INPUT_BRANCH
 
 # https://stackoverflow.com/a/2659808
 if git diff-index --quiet HEAD --; then
@@ -36,7 +36,7 @@ if [[ $INPUT_DRY_RUN == true ]]; then
 	git remote show origin
 	git show
 else
-	git push -u origin master
+	git push -u origin $INPUT_BRANCH
 fi
 
 rm -rf ./.git


### PR DESCRIPTION
- add an optional parameter: `branch`
    - default value: `master`
- fix #74 