### PR TITLE
Handle no-changed situation

### DIFF
--- a/src/index.sh
+++ b/src/index.sh
@@ -22,8 +22,8 @@ git remote add origin "https://$GITHUB_ACTOR:$INPUT_TOKEN@$INPUT_REPOSITORY.wiki
 git fetch origin
 git reset origin/master
 
-# https://stackoverflow.com/a/2659808
-if git diff-index --quiet HEAD --; then
+# https://stackoverflow.com/a/2658301
+if [[ $(git status --porcelain 2> /dev/null | tail -n1) == "" ]]; then
 	echo 'No changes! Will not commit or push.'
 	rm -rf .git
 	exit 0


### PR DESCRIPTION
Fix #76 

`git diff-index --quiet HEAD --` sometimes doesn't handle the no-changed situation.
Use `git status --porcelain` to handle modified, created, and deleted.